### PR TITLE
fix error in Practical 7 instructions

### DIFF
--- a/Practical7/Erratum.txt
+++ b/Practical7/Erratum.txt
@@ -1,0 +1,3 @@
+The original Practical guide asked you to show all rows and every third column from 0 to 15. This should be the other way around (and has now been corrected): Show all columns and every third row between 0 and 15.
+
+Many thanks to Liu Qi for pointing out the mistake!


### PR DESCRIPTION
There was a slight error in the instructions and marking criteria for Practical 7 (rows and columns swapped in one question). This was brought to my attention by Liu Qi. This version fixes the error and adds an Erratum.txt file explaining what the problem was.